### PR TITLE
Add encoding, wtap_encaps, wtap_tsprecs enums

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "stylua.targetReleaseVersion": "latest"
-}


### PR DESCRIPTION
This pull request adds the `encoding`, `wtap_encaps`, and `wtap_tsprecs` enums. Some of your functions' definitions were already using the enums without a definition for the enum values. This results in problem output from the LSP like so:

![Screenshot 2025-02-05 at 15 40 05](https://github.com/user-attachments/assets/51573a4e-3621-4cee-bd92-0f25780bc073)

I extracted the enums using the Wireshark Lua console to verify correctness. You can find the values using the following script, replacing the argument to `pairs()` as necessary.

```lua
for k,v in pairs(wtap_encaps) do
 print(k,v)
end
```
